### PR TITLE
latex rendering enabled

### DIFF
--- a/monsterui/core.py
+++ b/monsterui/core.py
@@ -112,7 +112,7 @@ class Theme(Enum):
     violet = auto()
     zinc = auto()
 
-    def _create_headers(self, urls, mode='auto', daisy=True, highlightjs=False):
+    def _create_headers(self, urls, mode='auto', daisy=True, highlightjs=False, katex=True):
         "Create header elements with given URLs"
         hdrs = [
             fh.Link(rel="stylesheet", href=urls['franken_css']),
@@ -153,14 +153,36 @@ class Theme(Enum):
                 ''', type='module'),
             ]
 
+        if katex:
+            hdrs += [
+                fh.Link(rel="stylesheet",
+                        href="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.css"),
+                fh.Script("""
+                import katex from 'https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.mjs';
+                import autoRender from 'https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/contrib/auto-render.mjs';
+                const options = {
+                  delimiters: [
+                    {left: '$$', right: '$$', display: true},
+                    {left: '$', right: '$', display: false}
+                  ],
+                  ignoredClasses: ['nomath']
+                };
+
+                document.addEventListener('htmx:load', evt => {
+                  const element = evt.detail.elt || document.body;
+                  autoRender(element,options);
+                });
+                """,type="module"),
+                ]
+
         return hdrs
 
-    def headers(self, mode='auto', daisy=True, highlightjs=False):
+    def headers(self, mode='auto', daisy=True, highlightjs=False, katex=True):
         "Create frankenui and tailwind cdns"
-        return self._create_headers(HEADER_URLS, mode=mode, daisy=daisy, highlightjs=highlightjs)    
+        return self._create_headers(HEADER_URLS, mode=mode, daisy=daisy, highlightjs=highlightjs, katex=katex)    
     
-    def local_headers(self, mode='auto', static_dir='static', daisy=True, highlightjs=False):
+    def local_headers(self, mode='auto', static_dir='static', daisy=True, highlightjs=False, katex=True):
         "Create headers using local files downloaded from CDNs"
         Path(static_dir).mkdir(exist_ok=True)
         local_urls = dict([_download_resource(url, static_dir) for url in HEADER_URLS.items()])
-        return self._create_headers(local_urls, mode=mode, daisy=daisy, highlightjs=highlightjs)
+        return self._create_headers(local_urls, mode=mode, daisy=daisy, highlightjs=highlightjs, katex=katex)

--- a/nbs/01_core.ipynb
+++ b/nbs/01_core.ipynb
@@ -250,7 +250,7 @@
     "    violet = auto()\n",
     "    zinc = auto()\n",
     "\n",
-    "    def _create_headers(self, urls, mode='auto', daisy=True, highlightjs=False):\n",
+    "    def _create_headers(self, urls, mode='auto', daisy=True, highlightjs=False, katex=True):\n",
     "        \"Create header elements with given URLs\"\n",
     "        hdrs = [\n",
     "            fh.Link(rel=\"stylesheet\", href=urls['franken_css']),\n",
@@ -291,24 +291,54 @@
     "                ''', type='module'),\n",
     "            ]\n",
     "\n",
+    "        if katex:\n",
+    "            hdrs += [\n",
+    "                fh.Link(rel=\"stylesheet\",\n",
+    "                        href=\"https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.css\"),\n",
+    "                fh.Script(\"\"\"\n",
+    "                import katex from 'https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.mjs';\n",
+    "                import autoRender from 'https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/contrib/auto-render.mjs';\n",
+    "                const options = {\n",
+    "                  delimiters: [\n",
+    "                    {left: '$$', right: '$$', display: true},\n",
+    "                    {left: '$', right: '$', display: false}\n",
+    "                  ],\n",
+    "                  ignoredClasses: ['nomath']\n",
+    "                };\n",
+    "\n",
+    "                document.addEventListener('htmx:load', evt => {\n",
+    "                  const element = evt.detail.elt || document.body;\n",
+    "                  autoRender(element,options);\n",
+    "                });\n",
+    "                \"\"\",type=\"module\"),\n",
+    "                ]\n",
+    "\n",
     "        return hdrs\n",
     "\n",
-    "    def headers(self, mode='auto', daisy=True, highlightjs=False):\n",
+    "    def headers(self, mode='auto', daisy=True, highlightjs=False, katex=True):\n",
     "        \"Create frankenui and tailwind cdns\"\n",
-    "        return self._create_headers(HEADER_URLS, mode=mode, daisy=daisy, highlightjs=highlightjs)    \n",
+    "        return self._create_headers(HEADER_URLS, mode=mode, daisy=daisy, highlightjs=highlightjs, katex=katex)    \n",
     "    \n",
-    "    def local_headers(self, mode='auto', static_dir='static', daisy=True, highlightjs=False):\n",
+    "    def local_headers(self, mode='auto', static_dir='static', daisy=True, highlightjs=False, katex=True):\n",
     "        \"Create headers using local files downloaded from CDNs\"\n",
     "        Path(static_dir).mkdir(exist_ok=True)\n",
     "        local_urls = dict([_download_resource(url, static_dir) for url in HEADER_URLS.items()])\n",
-    "        return self._create_headers(local_urls, mode=mode, daisy=daisy, highlightjs=highlightjs)"
+    "        return self._create_headers(local_urls, mode=mode, daisy=daisy, highlightjs=highlightjs, katex=katex)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "serving katex JS\n"
+     ]
+    }
+   ],
    "source": [
     "hdrs = Theme.blue.headers()\n",
     "app = FastHTML(hdrs=hdrs)"
@@ -318,7 +348,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "serving katex JS\n"
+     ]
+    }
+   ],
    "source": [
     "app, rt = fast_app(hdrs=Theme.blue.headers())\n",
     "Show = partial(HTMX, app=app)"

--- a/nbs/02_franken.ipynb
+++ b/nbs/02_franken.ipynb
@@ -2792,21 +2792,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The behavior is as follows:

- latex rendering is on by default, rendering all latex markup found in all tags which katex renders by default, as specified at:
   https://katex.org/docs/autorender.html
- developers can opt-out of latex rendering on a per-element basis, by adding the class "nomath"
- developers can turn it off globally, by settting katex=False in create_headers
