### PR TITLE
fix: remove problematic line in theme switcher script

### DIFF
--- a/monsterui/core.py
+++ b/monsterui/core.py
@@ -55,7 +55,6 @@ def _headers_theme(color, mode='auto'):
     return fh.Script(f'''
         const htmlElement = document.documentElement;
         {mode_script[mode]}
-        htmlElement.classList.add(localStorage.getItem("theme") || "uk-theme-{color}");
           htmlElement.classList.add(__FRANKEN__.theme || "uk-theme-{color}");
           htmlElement.classList.add(__FRANKEN__.radii || "uk-radii-md");
           htmlElement.classList.add(__FRANKEN__.shadows || "uk-shadows-sm");

--- a/nbs/01_core.ipynb
+++ b/nbs/01_core.ipynb
@@ -173,7 +173,6 @@
     "    return fh.Script(f'''\n",
     "        const htmlElement = document.documentElement;\n",
     "        {mode_script[mode]}\n",
-    "        htmlElement.classList.add(localStorage.getItem(\"theme\") || \"uk-theme-{color}\");\n",
     "          htmlElement.classList.add(__FRANKEN__.theme || \"uk-theme-{color}\");\n",
     "          htmlElement.classList.add(__FRANKEN__.radii || \"uk-radii-md\");\n",
     "          htmlElement.classList.add(__FRANKEN__.shadows || \"uk-shadows-sm\");\n",


### PR DESCRIPTION
# Fix: Remove problematic line in theme switcher script

## Issue
The theme color does not use the user preference after refreshing the browser, rather it defaults to the color that we added in the header when initiating.

## Evidence
- The error occurred because the default theme color is added twice in the HTML class (one from the `Theme` item and another one from the `__FRANKEN__` item), which overrides the user's theme preference.
- As per the  [Theme Switcher Docs](https://next.franken-ui.dev/docs/2.0/theme-switcher) we don't need the `Theme` item.

Screenshots showing the conflict:
![image](https://github.com/user-attachments/assets/a767dc60-d28b-41ae-9576-cb78f46db039)

![image](https://github.com/user-attachments/assets/2212a5b6-a97c-4c02-951f-8bfca5b02119)

