### PR TITLE
Fix: Tutorial App not loading #63

### DIFF
--- a/docs/main.py
+++ b/docs/main.py
@@ -165,24 +165,8 @@ def theme_switcher(request):
 
 gs_path = Path('getting_started')
 
-@rt('/getting_started')
-@rt('/getting_started/{o}')
-def getting_started(o:str='', request=None):
-    if o=='md': return PlainTextResponse(read_html(f'https://monsterui.answer.ai/getting_started', sel='#content'))
-    if o=='rmd': return Div(render_md(read_html(f'https://monsterui.answer.ai/getting_started', sel='#content')))
-    content = Container(render_md(open(gs_path/'GettingStarted.md').read()))
-    return _create_page(content, 
-                       request, 
-                       'Getting Started')
-@rt('/')
-@rt('/{o}')
-def index(o:str='', request=None):
-    if o=='md': return PlainTextResponse(read_html(f'https://monsterui.answer.ai', sel='#content'))
-    if o=='rmd': return Div(render_md(read_html(f'https://monsterui.answer.ai', sel='#content')))
-    return getting_started('')
-
-@rt('/tutorial_app2')
-@rt('/tutorial_app2/{o}')
+@rt('/tutorial_app')
+@rt('/tutorial_app/{o}')
 def tutorial_app(o:str='', request=None):
     pass
     if o=='md': return PlainTextResponse(read_html(f'https://monsterui.answer.ai/tutorial_app', sel='#content'))
@@ -207,6 +191,21 @@ For example, try replacing `H4` with `fh.H4` or `Button` with `fh.Button`."""),
         app_rendered)
     return _create_page(content, request, 'Getting Started')
 
+@rt('/getting_started')
+@rt('/getting_started/{o}')
+def getting_started(o:str='', request=None):
+    if o=='md': return PlainTextResponse(read_html(f'https://monsterui.answer.ai/getting_started', sel='#content'))
+    if o=='rmd': return Div(render_md(read_html(f'https://monsterui.answer.ai/getting_started', sel='#content')))
+    content = Container(render_md(open(gs_path/'GettingStarted.md').read()))
+    return _create_page(content, 
+                       request, 
+                       'Getting Started')
+@rt('/')
+@rt('/{o}')
+def index(o:str='', request=None):
+    if o=='md': return PlainTextResponse(read_html(f'https://monsterui.answer.ai', sel='#content'))
+    if o=='rmd': return Div(render_md(read_html(f'https://monsterui.answer.ai', sel='#content')))
+    return getting_started('')
 
 ###
 # Build the Sidebar

--- a/docs/main.py
+++ b/docs/main.py
@@ -191,21 +191,13 @@ For example, try replacing `H4` with `fh.H4` or `Button` with `fh.Button`."""),
         app_rendered)
     return _create_page(content, request, 'Getting Started')
 
-@rt('/getting_started')
-@rt('/getting_started/{o}')
-def getting_started(o:str='', request=None):
-    if o=='md': return PlainTextResponse(read_html(f'https://monsterui.answer.ai/getting_started', sel='#content'))
-    if o=='rmd': return Div(render_md(read_html(f'https://monsterui.answer.ai/getting_started', sel='#content')))
-    content = Container(render_md(open(gs_path/'GettingStarted.md').read()))
-    return _create_page(content, 
-                       request, 
-                       'Getting Started')
 @rt('/')
 @rt('/{o}')
 def index(o:str='', request=None):
-    if o=='md': return PlainTextResponse(read_html(f'https://monsterui.answer.ai', sel='#content'))
-    if o=='rmd': return Div(render_md(read_html(f'https://monsterui.answer.ai', sel='#content')))
-    return getting_started('')
+    if o=='md': return PlainTextResponse(read_html(f'https://monsterui.answer.ai/getting_started', sel='#content'))
+    if o=='rmd': return Div(render_md(read_html(f'https://monsterui.answer.ai/getting_started', sel='#content')))
+    content = Container(render_md(open(gs_path/'GettingStarted.md').read()))
+    return _create_page(content, request,  'Getting Started')
 
 ###
 # Build the Sidebar
@@ -218,8 +210,8 @@ def sidebar(open_section):
     return NavContainer(
         NavParentLi(
             A(DivFullySpaced("Getting Started", )),
-            NavContainer(create_li("Getting Started", getting_started),
-                         create_li("Tutorial App", '/tutorial_app'),
+            NavContainer(create_li("Getting Started", index),
+                         create_li("Tutorial App", tutorial_app),
                          parent=False),
             cls='uk-open' if open_section=='Getting Started' else ''
         ),


### PR DESCRIPTION
- tutorial_app2 route changed to tutorial_app
- moved tutorial_app to be before getting_started because it was catching the request for some reason.

I'm not sure this is a good fix. I looked and I can't figure out why the getting_started endpoint is catching the tutorial_app. I tried changing the Li in the Navbar to be the function and a string and no matter what the request was empty and I couldn't get the tutorial_app endpoint to ever run. Moving it above the getting_started 'fixed' it but I don't understand why it is catching it.