### PR TITLE
suppress katex rendering within monaco editor

### DIFF
--- a/monsterui/core.py
+++ b/monsterui/core.py
@@ -204,7 +204,7 @@ class Theme(Enum):
                     {left: '$$', right: '$$', display: true},
                     {left: '$', right: '$', display: false}
                   ],
-                  ignoredClasses: ['nomath']
+                  ignoredClasses: ['nomath', 'monaco-editor']
                 };
 
                 document.addEventListener('htmx:load', evt => {

--- a/nbs/01_core.ipynb
+++ b/nbs/01_core.ipynb
@@ -349,7 +349,7 @@
     "                    {left: '$$', right: '$$', display: true},\n",
     "                    {left: '$', right: '$', display: false}\n",
     "                  ],\n",
-    "                  ignoredClasses: ['nomath']\n",
+    "                  ignoredClasses: ['nomath', 'monaco-editor']\n",
     "                };\n",
     "\n",
     "                document.addEventListener('htmx:load', evt => {\n",


### PR DESCRIPTION
This modifies howMonsterUI uses KaTeX, so that KaTeX does not try to render the LaTeX markdown which is inside the Monaco editing area.


 