### PR TITLE
Headers theme selection

### DIFF
--- a/monsterui/core.py
+++ b/monsterui/core.py
@@ -51,23 +51,25 @@ class ThemeFont:
 
 # %% ../nbs/01_core.ipynb
 def _headers_theme(color, mode='auto', radii=ThemeRadii.sm, shadows=ThemeShadows.sm, font=ThemeFont.sm):
-    mode_script = {
-        'auto': '''
+    franken_init = '''
           const __FRANKEN__ = JSON.parse(localStorage.getItem("__FRANKEN__") || "{}");
-
+    '''
+    
+    mode_script = {
+        'auto': f'''
+          {franken_init}
           if (
             __FRANKEN__.mode === "dark" ||
             (!__FRANKEN__.mode &&
               window.matchMedia("(prefers-color-scheme: dark)").matches)
-          ) {
+          ) {{
             htmlElement.classList.add("dark");
-          } else {
+          }} else {{
             htmlElement.classList.remove("dark");
-          }
-
+          }}
         ''',
-        'light': 'htmlElement.classList.remove("dark");',
-        'dark': 'htmlElement.classList.add("dark");'
+        'light': f'{franken_init}\nhtmlElement.classList.remove("dark");',
+        'dark': f'{franken_init}\nhtmlElement.classList.add("dark");'
     }
     
     return fh.Script(f'''
@@ -106,16 +108,31 @@ def _download_resource(url, static_dir):
 # %% ../nbs/01_core.ipynb
 daisy_styles = Style("""
 :root {
+  --b1: from hsl(var(--background)) l c h;
+  --bc: from hsl(var(--foreground)) l c h;
+  --m: from hsl(var(--muted)) l c h;
+  --mc: from hsl(var(--muted-foreground)) l c h;
+  --po: from hsl(var(--popover)) l c h;
+  --poc: from hsl(var(--popover-foreground)) l c h;
+  --b2: from hsl(var(--card)) l c h;
+  --b2c: from hsl(var(--card-foreground)) l c h;
+  --br: from hsl(var(--border)) l c h;
+  --in: from hsl(var(--input)) l c h;
   --p: from hsl(var(--primary)) l c h;
   --pc: from hsl(var(--primary-foreground)) l c h;
   --s: from hsl(var(--secondary)) l c h;
   --sc: from hsl(var(--secondary-foreground)) l c h;
-  --b2: from hsl(var(--card-background)) l c h;
-  --b1: from hsl(var(--background)) l c h;
-  --bc: from hsl(var(--foreground)) l c h;
-  --b3: from hsl(var(--ring)) l c h;
+  --a: from hsl(var(--accent)) l c h;
+  --ac: from hsl(var(--accent-foreground)) l c h;
   --er: from hsl(var(--destructive)) l c h;
   --erc: from hsl(var(--destructive-foreground)) l c h;
+  --b3: from hsl(var(--ring)) l c h;
+  --ch1: from hsl(var(--chart-1)) l c h;
+  --ch2: from hsl(var(--chart-2)) l c h;
+  --ch3: from hsl(var(--chart-3)) l c h;
+  --ch4: from hsl(var(--chart-4)) l c h;
+  --ch5: from hsl(var(--chart-5)) l c h;
+  --rd: var(--radius);
 }
 """)
 

--- a/nbs/01_core.ipynb
+++ b/nbs/01_core.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -120,7 +120,7 @@
        "{'pico': False, 'something': 'test', 'class': ' bg-background text-foreground'}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -145,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -239,7 +239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -417,7 +417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -427,7 +427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,18 +465,6 @@
    "display_name": "python3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.13.1"
   }
  },
  "nbformat": 4,

--- a/nbs/01_core.ipynb
+++ b/nbs/01_core.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -120,7 +120,7 @@
        "{'pico': False, 'something': 'test', 'class': ' bg-background text-foreground'}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -145,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,29 +169,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
     "def _headers_theme(color, mode='auto', radii=ThemeRadii.sm, shadows=ThemeShadows.sm, font=ThemeFont.sm):\n",
-    "    mode_script = {\n",
-    "        'auto': '''\n",
+    "    franken_init = '''\n",
     "          const __FRANKEN__ = JSON.parse(localStorage.getItem(\"__FRANKEN__\") || \"{}\");\n",
-    "\n",
+    "    '''\n",
+    "    \n",
+    "    mode_script = {\n",
+    "        'auto': f'''\n",
+    "          {franken_init}\n",
     "          if (\n",
     "            __FRANKEN__.mode === \"dark\" ||\n",
     "            (!__FRANKEN__.mode &&\n",
     "              window.matchMedia(\"(prefers-color-scheme: dark)\").matches)\n",
-    "          ) {\n",
+    "          ) {{\n",
     "            htmlElement.classList.add(\"dark\");\n",
-    "          } else {\n",
+    "          }} else {{\n",
     "            htmlElement.classList.remove(\"dark\");\n",
-    "          }\n",
-    "\n",
+    "          }}\n",
     "        ''',\n",
-    "        'light': 'htmlElement.classList.remove(\"dark\");',\n",
-    "        'dark': 'htmlElement.classList.add(\"dark\");'\n",
+    "        'light': f'{franken_init}\\nhtmlElement.classList.remove(\"dark\");',\n",
+    "        'dark': f'{franken_init}\\nhtmlElement.classList.add(\"dark\");'\n",
     "    }\n",
     "    \n",
     "    return fh.Script(f'''\n",
@@ -207,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,30 +239,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
     "daisy_styles = Style(\"\"\"\n",
     ":root {\n",
+    "  --b1: from hsl(var(--background)) l c h;\n",
+    "  --bc: from hsl(var(--foreground)) l c h;\n",
+    "  --m: from hsl(var(--muted)) l c h;\n",
+    "  --mc: from hsl(var(--muted-foreground)) l c h;\n",
+    "  --po: from hsl(var(--popover)) l c h;\n",
+    "  --poc: from hsl(var(--popover-foreground)) l c h;\n",
+    "  --b2: from hsl(var(--card)) l c h;\n",
+    "  --b2c: from hsl(var(--card-foreground)) l c h;\n",
+    "  --br: from hsl(var(--border)) l c h;\n",
+    "  --in: from hsl(var(--input)) l c h;\n",
     "  --p: from hsl(var(--primary)) l c h;\n",
     "  --pc: from hsl(var(--primary-foreground)) l c h;\n",
     "  --s: from hsl(var(--secondary)) l c h;\n",
     "  --sc: from hsl(var(--secondary-foreground)) l c h;\n",
-    "  --b2: from hsl(var(--card-background)) l c h;\n",
-    "  --b1: from hsl(var(--background)) l c h;\n",
-    "  --bc: from hsl(var(--foreground)) l c h;\n",
-    "  --b3: from hsl(var(--ring)) l c h;\n",
+    "  --a: from hsl(var(--accent)) l c h;\n",
+    "  --ac: from hsl(var(--accent-foreground)) l c h;\n",
     "  --er: from hsl(var(--destructive)) l c h;\n",
     "  --erc: from hsl(var(--destructive-foreground)) l c h;\n",
+    "  --b3: from hsl(var(--ring)) l c h;\n",
+    "  --ch1: from hsl(var(--chart-1)) l c h;\n",
+    "  --ch2: from hsl(var(--chart-2)) l c h;\n",
+    "  --ch3: from hsl(var(--chart-3)) l c h;\n",
+    "  --ch4: from hsl(var(--chart-4)) l c h;\n",
+    "  --ch5: from hsl(var(--chart-5)) l c h;\n",
+    "  --rd: var(--radius);\n",
     "}\n",
     "\"\"\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,17 +417,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "serving katex JS\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "hdrs = Theme.blue.headers()\n",
     "app = FastHTML(hdrs=hdrs)"
@@ -418,17 +427,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "serving katex JS\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "app, rt = fast_app(hdrs=Theme.blue.headers())\n",
     "Show = partial(HTMX, app=app)"
@@ -443,13 +444,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
     "#| hide\n",
     "import nbdev; nbdev.nbdev_export()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -457,6 +465,18 @@
    "display_name": "python3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I've tested out feeding the theme settings into the headers function as arguments, like so:

`hdrs = Theme.rose.headers(mode="light", radii=ThemeRadii.lg, shadows=ThemeShadows.sm, font=ThemeFont.default)`

While it worked when the `mode` argument was omitted, or when `mode="auto"`, it didn't work when `mode="light"` or `mode="dark"`. I think the reason was because `__FRANKEN__` was only being defined when `mode="auto"`, which lead to script in `_headers_theme()` not executing properly if either `dark` or `light` was specified. I've added a fix that hopfully corrects this behaviour.

Also, playing around with DaisyUI themes, I noticed that not all semantic colour utility classes were being defined, so I added them (list taken from [https://ui.jln.dev/](https://ui.jln.dev/)).

This is my first contribution to an open source project, so if anything I've done is wrong, out of scope, lacking etc. please let me know. 

Cheers!