### PR TITLE
Fix theme logic

### DIFF
--- a/monsterui/core.py
+++ b/monsterui/core.py
@@ -75,7 +75,6 @@ def _headers_theme(color, mode='auto', radii=ThemeRadii.sm, shadows=ThemeShadows
     return fh.Script(f'''
         const htmlElement = document.documentElement;
         {mode_script[mode]}
-          htmlElement.classList.add("uk-theme-{color}");
           htmlElement.classList.add(__FRANKEN__.theme || "uk-theme-{color}");
           htmlElement.classList.add(__FRANKEN__.radii || "{radii}");
           htmlElement.classList.add(__FRANKEN__.shadows || "{shadows}");

--- a/nbs/01_core.ipynb
+++ b/nbs/01_core.ipynb
@@ -199,7 +199,6 @@
     "    return fh.Script(f'''\n",
     "        const htmlElement = document.documentElement;\n",
     "        {mode_script[mode]}\n",
-    "          htmlElement.classList.add(\"uk-theme-{color}\");\n",
     "          htmlElement.classList.add(__FRANKEN__.theme || \"uk-theme-{color}\");\n",
     "          htmlElement.classList.add(__FRANKEN__.radii || \"{radii}\");\n",
     "          htmlElement.classList.add(__FRANKEN__.shadows || \"{shadows}\");\n",


### PR DESCRIPTION
Tiny PR to address theme loading issues. Currently when changing the theme via the modal, it saves to localStorage correctly but both the `default` theme *and* the localStorage preference are added to the html tag. This is causing conflicts where certain themes are overriding others.

Removing the additional `htmlElement.classList.add("uk-theme-{color}");` snippet ensures the theme matches the option set in storage, or uses to the default if none is set. This is how it's documented in FrankenUI, so I'm guessing it was added on purpose - let me know the functionality you were aiming for and we can try to find another solution!