### PR TITLE
fix font weight ordering

### DIFF
--- a/monsterui/franken.py
+++ b/monsterui/franken.py
@@ -50,7 +50,7 @@ class TextT(VEnum):
     # Text Size
     xs, sm, lg, xl = 'text-xs', 'text-sm', 'text-lg', 'text-xl'
     # Text Weight
-    light, normal, medium, bold, extrabold = 'font-normal','font-light','font-medium','font-bold','font-extrabold'
+    light, normal, medium, bold, extrabold = 'font-light','font-normal','font-medium','font-bold','font-extrabold'
     # Text Color
     muted,primary,secondary = 'text-gray-500 dark:text-gray-200', 'text-primary', 'text-secondary'
     success,warning, error, info =  'text-success', 'text-warning', 'text-error', 'text-info'

--- a/nbs/02_franken.ipynb
+++ b/nbs/02_franken.ipynb
@@ -125,7 +125,7 @@
     "    # Text Size\n",
     "    xs, sm, lg, xl = 'text-xs', 'text-sm', 'text-lg', 'text-xl'\n",
     "    # Text Weight\n",
-    "    light, normal, medium, bold, extrabold = 'font-normal','font-light','font-medium','font-bold','font-extrabold'\n",
+    "    light, normal, medium, bold, extrabold = 'font-light','font-normal','font-medium','font-bold','font-extrabold'\n",
     "    # Text Color\n",
     "    muted,primary,secondary = 'text-gray-500 dark:text-gray-200', 'text-primary', 'text-secondary'\n",
     "    success,warning, error, info =  'text-success', 'text-warning', 'text-error', 'text-info'\n",


### PR DESCRIPTION
This pr fixes the ordering of the `TextT` font weights so that the variables match the values. See #106 for more info.