### PR TITLE
Fix typo in custom cls argument Select component

### DIFF
--- a/monsterui/franken.py
+++ b/monsterui/franken.py
@@ -821,7 +821,7 @@ def Options(*c,                    # Content for an `Option`
 def Select(*option,            # Options for the select dropdown (can use `Options` helper function to create)
           inp_cls=(),         # Additional classes for the select input
           cls=('h-10',),      # Classes for the outer div (default h-10 for consistent height)
-          cls_custom='button: uk-input-fake dropdown: w-full', # Classes for the Uk_Select web component
+          cls_custom='button: uk-input-fake; dropdown: w-full', # Classes for the Uk_Select web component
           id="",              # ID for the select input
           name="",            # Name attribute for the select input
           placeholder="",     # Placeholder text for the select input


### PR DESCRIPTION
Because of the missing semicolon the dropdown is not rendered in full width. See also franken ui documentation:

```
<div class="h-10">
  <uk-select cls-custom="button: uk-input-fake w-full; dropdown: w-full">
    <select hidden>
      <option value="option1">Option 1</option>
      <option value="option2">Option 2</option>
      <option value="option3">Option 3</option>
      <option value="option4">Option 4</option>
      <option value="option5">Option 5</option>
    </select>
  </uk-select>
</div>
```