### PR TITLE
Fix cls_custom default value for Select Component

### DIFF
--- a/nbs/02_franken.ipynb
+++ b/nbs/02_franken.ipynb
@@ -1524,7 +1524,7 @@
     "def Select(*option,            # Options for the select dropdown (can use `Options` helper function to create)\n",
     "          inp_cls=(),         # Additional classes for the select input\n",
     "          cls=('h-10',),      # Classes for the outer div (default h-10 for consistent height)\n",
-    "          cls_custom='button: uk-input-fake dropdown: w-full', # Classes for the Uk_Select web component\n",
+    "          cls_custom='button: uk-input-fake; dropdown: w-full', # Classes for the Uk_Select web component\n",
     "          id=\"\",              # ID for the select input\n",
     "          name=\"\",            # Name attribute for the select input\n",
     "          placeholder=\"\",     # Placeholder text for the select input\n",


### PR DESCRIPTION
Without the semicolon the dropdown is not rendered in full width. See also franken ui documentation:


```
<div class="h-10">
  <uk-select cls-custom="button: uk-input-fake w-full; dropdown: w-full">
    <select hidden>
      <option value="option1">Option 1</option>
      <option value="option2">Option 2</option>
      <option value="option3">Option 3</option>
      <option value="option4">Option 4</option>
      <option value="option5">Option 5</option>
    </select>
  </uk-select>
</div>
```