### PR TITLE
remove modal on close

### DIFF
--- a/monsterui/franken.py
+++ b/monsterui/franken.py
@@ -993,6 +993,7 @@ def Modal(*c,                 # Components to put in the `ModalBody` (often form
     if not id: id = fh.unqid()
     if hx_open: kwargs["hx_on__load"] = f"UIkit.modal('#{id}').show()"
     if hx_init and not hx_open: kwargs["hx_on__load"] = f"UIkit.modal('#{id}')"
+    if hx_open or hx_init: kwargs["hx-on:hidden"] = "this.remove()"
     cls, dialog_cls, header_cls, body_cls, footer_cls = map(stringify, (cls, dialog_cls, header_cls, body_cls, footer_cls))
     res = []
     if header: res.append(ModalHeader(cls=header_cls)(header))

--- a/nbs/02_franken.ipynb
+++ b/nbs/02_franken.ipynb
@@ -1810,6 +1810,7 @@
     "    if not id: id = fh.unqid()\n",
     "    if hx_open: kwargs[\"hx_on__load\"] = f\"UIkit.modal('#{id}').show()\"\n",
     "    if hx_init and not hx_open: kwargs[\"hx_on__load\"] = f\"UIkit.modal('#{id}')\"\n",
+    "    if hx_open or hx_init: kwargs[\"hx-on:hidden\"] = \"this.remove()\"\n",
     "    cls, dialog_cls, header_cls, body_cls, footer_cls = map(stringify, (cls, dialog_cls, header_cls, body_cls, footer_cls))\n",
     "    res = []\n",
     "    if header: res.append(ModalHeader(cls=header_cls)(header))\n",


### PR DESCRIPTION
#129 

Modals are not removed from the DOM on close. This could cause issues if the modal is open/closed multiple times. This pr adds some logic to automatically remove the modal from the DOM on close.



https://github.com/user-attachments/assets/10c6df13-146a-4737-b969-59d3941f7ea5

