### PR TITLE
Change default value of `cls` for ModalCloseButton

### DIFF
--- a/nbs/02_franken.ipynb
+++ b/nbs/02_franken.ipynb
@@ -1776,7 +1776,7 @@
     "    \"Creates a modal title\"\n",
     "    return fh.H2(*c,  cls=('uk-modal-title',  stringify(cls)),  **kwargs)\n",
     "def ModalCloseButton(*c, # Components to put in the button (often text and/or an icon)\n",
-    "                      cls=\"absolute top-3 right-3\", # Additional classes on the button\n",
+    "                      cls=\"ButtonT.default\", # Additional classes on the button\n",
     "                      **kwargs # Additional args for `Button` tag\n",
     "                      )->FT: # Button(..., cls='uk-modal-close')\n",
     "    \"Creates a button that closes a modal with js\"\n",


### PR DESCRIPTION
With the current default value the button doesn't render (or at least not in a position where you need it :))

`ButtonT.default` is also the default class on `Button` component