### PR TITLE
fix `render_md` non http/s urls

### DIFF
--- a/monsterui/franken.py
+++ b/monsterui/franken.py
@@ -1553,7 +1553,7 @@ def get_franken_renderer(img_dir):
             template = '<img src="{}" alt="{}"{} class="max-w-full h-auto rounded-lg mb-6">'
             title = f' title="{token.title}"' if hasattr(token, 'title') else ''
             src = token.src
-            if img_dir and not src.startswith(('http://', 'https://', '/')):
+            if img_dir and not src.startswith(('http://', 'https://', '/', 'attachment:', 'blob:', 'data:')):
                 src = f'{pathlib.Path(img_dir)}/{src}'
             return template.format(src, token.children[0].content if token.children else '', title)
     return FrankenRenderer

--- a/nbs/02_franken.ipynb
+++ b/nbs/02_franken.ipynb
@@ -451,7 +451,7 @@
     {
      "data": {
       "text/html": [
-       "<iframe src=\"http://localhost:8000/_jRNIGvTsQISfQ9f4u9CJAQ\" style=\"width: 100%; height: auto; border: none;\" onload=\"{\n",
+       "<iframe src=\"http://localhost:8000/_5LD0Qk7fQG2BpDyC1VAEbw\" style=\"width: 100%; height: auto; border: none;\" onload=\"{\n",
        "        let frame = this;\n",
        "        window.addEventListener('message', function(e) {\n",
        "            if (e.source !== frame.contentWindow) return; // Only proceed if the message is from this iframe\n",
@@ -1167,7 +1167,7 @@
     {
      "data": {
       "text/html": [
-       "<a href=\"http://localhost:8000/_M6zpWKgqTvKGSmFW1LZNRg\" target=\"_blank\">Open in new tab</a>"
+       "<a href=\"http://localhost:8000/_w3FTt22HRf23fdXTLi4eGw\" target=\"_blank\">Open in new tab</a>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -1179,7 +1179,7 @@
     {
      "data": {
       "text/html": [
-       "<iframe src=\"http://localhost:8000/_M6zpWKgqTvKGSmFW1LZNRg\" style=\"width: 100%; height: auto; border: none;\" onload=\"{\n",
+       "<iframe src=\"http://localhost:8000/_w3FTt22HRf23fdXTLi4eGw\" style=\"width: 100%; height: auto; border: none;\" onload=\"{\n",
        "        let frame = this;\n",
        "        window.addEventListener('message', function(e) {\n",
        "            if (e.source !== frame.contentWindow) return; // Only proceed if the message is from this iframe\n",
@@ -1600,7 +1600,7 @@
     {
      "data": {
       "text/html": [
-       "<iframe src=\"http://localhost:8000/_i3dfd3ZcRNiJUQ_VWokKtQ\" style=\"width: 100%; height: auto; border: none;\" onload=\"{\n",
+       "<iframe src=\"http://localhost:8000/_iAoSfI6gSuKeaSNqrKohlA\" style=\"width: 100%; height: auto; border: none;\" onload=\"{\n",
        "        let frame = this;\n",
        "        window.addEventListener('message', function(e) {\n",
        "            if (e.source !== frame.contentWindow) return; // Only proceed if the message is from this iframe\n",
@@ -1867,7 +1867,7 @@
     {
      "data": {
       "text/html": [
-       "<iframe src=\"http://localhost:8000/_jDd25C_CTIajV0bsMTjzOg\" style=\"width: 100%; height: 500px; border: none;\" onload=\"\" allow=\"accelerometer; autoplay; camera; clipboard-read; clipboard-write; display-capture; encrypted-media; fullscreen; gamepad; geolocation; gyroscope; hid; identity-credentials-get; idle-detection; magnetometer; microphone; midi; payment; picture-in-picture; publickey-credentials-get; screen-wake-lock; serial; usb; web-share; xr-spatial-tracking\"></iframe> "
+       "<iframe src=\"http://localhost:8000/_BKeCyjE2TAyJCPV2_Le9Og\" style=\"width: 100%; height: 500px; border: none;\" onload=\"\" allow=\"accelerometer; autoplay; camera; clipboard-read; clipboard-write; display-capture; encrypted-media; fullscreen; gamepad; geolocation; gyroscope; hid; identity-credentials-get; idle-detection; magnetometer; microphone; midi; payment; picture-in-picture; publickey-credentials-get; screen-wake-lock; serial; usb; web-share; xr-spatial-tracking\"></iframe> "
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -2970,7 +2970,7 @@
     {
      "data": {
       "text/html": [
-       "<iframe src=\"http://localhost:8008/_lcysiC5NRne3jeT4Roy0Jg\" style=\"width: 100%; height: auto; border: none;\" onload=\"{\n",
+       "<iframe src=\"http://localhost:8008/_Z8F24y_hQMiCbnED9WguJg\" style=\"width: 100%; height: auto; border: none;\" onload=\"{\n",
        "        let frame = this;\n",
        "        window.addEventListener('message', function(e) {\n",
        "            if (e.source !== frame.contentWindow) return; // Only proceed if the message is from this iframe\n",
@@ -3130,7 +3130,7 @@
     "            template = '<img src=\"{}\" alt=\"{}\"{} class=\"max-w-full h-auto rounded-lg mb-6\">'\n",
     "            title = f' title=\"{token.title}\"' if hasattr(token, 'title') else ''\n",
     "            src = token.src\n",
-    "            if img_dir and not src.startswith(('http://', 'https://', '/')):\n",
+    "            if img_dir and not src.startswith(('http://', 'https://', '/', 'attachment:', 'blob:', 'data:')):\n",
     "                src = f'{pathlib.Path(img_dir)}/{src}'\n",
     "            return template.format(src, token.children[0].content if token.children else '', title)\n",
     "    return FrankenRenderer"
@@ -3167,15 +3167,21 @@
      "output_type": "stream",
      "text": [
       "<p class=\"text-lg leading-relaxed mb-6\"><img src=\"/users/isaac-flath/my_image.png\" alt=\"test\" title=\"\" class=\"max-w-full h-auto rounded-lg mb-6 max-w-full h-auto rounded-lg mb-6\"></p>\n",
+      "\n",
       "<p class=\"text-lg leading-relaxed mb-6\"><img src=\"static/my_image.png\" alt=\"test\" title=\"\" class=\"max-w-full h-auto rounded-lg mb-6 max-w-full h-auto rounded-lg mb-6\"></p>\n",
-      "<p class=\"text-lg leading-relaxed mb-6\"><img src=\"https://example.com/img.png\" alt=\"test\" title=\"\" class=\"max-w-full h-auto rounded-lg mb-6 max-w-full h-auto rounded-lg mb-6\"></p>\n"
+      "\n",
+      "<p class=\"text-lg leading-relaxed mb-6\"><img src=\"https://example.com/img.png\" alt=\"test\" title=\"\" class=\"max-w-full h-auto rounded-lg mb-6 max-w-full h-auto rounded-lg mb-6\"></p>\n",
+      "\n",
+      "<p class=\"text-lg leading-relaxed mb-6\"><img src=\"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiB\" alt=\"test\" title=\"\" class=\"max-w-full h-auto rounded-lg mb-6 max-w-full h-auto rounded-lg mb-6\"></p>\n",
+      "\n"
      ]
     }
    ],
    "source": [
     "print(render_md('![test](/users/isaac-flath/my_image.png)', img_dir='static'))\n",
     "print(render_md('![test](my_image.png)', img_dir='static'))\n",
-    "print(render_md('![test](https://example.com/img.png)', img_dir='static'))"
+    "print(render_md('![test](https://example.com/img.png)', img_dir='static'))\n",
+    "print(render_md('![test](data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiB)', img_dir='static'))"
    ]
   },
   {
@@ -3222,7 +3228,7 @@
     {
      "data": {
       "text/html": [
-       "<iframe src=\"http://localhost:8008/_9sqkIqasTvOdm8snfj32IA\" style=\"width: 100%; height: auto; border: none;\" onload=\"{\n",
+       "<iframe src=\"http://localhost:8008/_Rjgl0haMQ2iP59xOmxmqig\" style=\"width: 100%; height: auto; border: none;\" onload=\"{\n",
        "        let frame = this;\n",
        "        window.addEventListener('message', function(e) {\n",
        "            if (e.source !== frame.contentWindow) return; // Only proceed if the message is from this iframe\n",
@@ -3294,7 +3300,7 @@
     {
      "data": {
       "text/html": [
-       "<iframe src=\"http://localhost:8008/_N-s11_PFTo2VVA-wtJUCwA\" style=\"width: 100%; height: 350px; border: none;\" onload=\"\" allow=\"accelerometer; autoplay; camera; clipboard-read; clipboard-write; display-capture; encrypted-media; fullscreen; gamepad; geolocation; gyroscope; hid; identity-credentials-get; idle-detection; magnetometer; microphone; midi; payment; picture-in-picture; publickey-credentials-get; screen-wake-lock; serial; usb; web-share; xr-spatial-tracking\"></iframe> "
+       "<iframe src=\"http://localhost:8008/_GXhX1QgfStivfBjaSa8ayw\" style=\"width: 100%; height: 350px; border: none;\" onload=\"\" allow=\"accelerometer; autoplay; camera; clipboard-read; clipboard-write; display-capture; encrypted-media; fullscreen; gamepad; geolocation; gyroscope; hid; identity-credentials-get; idle-detection; magnetometer; microphone; midi; payment; picture-in-picture; publickey-credentials-get; screen-wake-lock; serial; usb; web-share; xr-spatial-tracking\"></iframe> "
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -3601,7 +3607,7 @@
     {
      "data": {
       "text/html": [
-       "<iframe src=\"http://localhost:8008/_bL-ObMZ2Qqyzn1fQ73N3EA\" style=\"width: 100%; height: auto; border: none;\" onload=\"{\n",
+       "<iframe src=\"http://localhost:8008/_1XCdP2InSESFkkurKNnfHw\" style=\"width: 100%; height: auto; border: none;\" onload=\"{\n",
        "        let frame = this;\n",
        "        window.addEventListener('message', function(e) {\n",
        "            if (e.source !== frame.contentWindow) return; // Only proceed if the message is from this iframe\n",


### PR DESCRIPTION
#132 

`render_md` doesn't render images with data uris when img_dir is set.  For example this img will render just fine.

```python
img = "![Red](data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCIgdmlld0JveD0iMCAwIDEwMCAxMDAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPGNpcmNsZSBjeD0iNTAiIGN5PSI1MCIgcj0iNDAiIGZpbGw9InJlZCIvPgo8L3N2Zz4K)"

render_md(img)
```

If we set `img_dir` like this `render_md(img, img_dir='static')` it no longer renders because `static` gets prepended to the rendered img tag like this `<img src="static/data:image....">`. 

The fix is straightforward. We simple expand the list of cases in `render_md` when we don't prepend `img_dir` to the source [here](https://github.com/AnswerDotAI/MonsterUI/blob/main/monsterui/franken.py#L1556). 

https://github.com/user-attachments/assets/65e5438e-4021-48ad-972f-1a573094da1d

