### PR TITLE
fix SyntaxWarning for Python 3.13 compatibility

### DIFF
--- a/monsterui/franken.py
+++ b/monsterui/franken.py
@@ -1630,7 +1630,7 @@ def ApexChart(*,
     return Div(Uk_chart(js), cls=stringify(cls), **kws)
 
 # %% ../nbs/02_franken.ipynb
-spy_js = '''
+spy_js = r'''
 const slug = (s) => s.toLowerCase().trim().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-');
 const frag = document.createDocumentFragment();
 


### PR DESCRIPTION
## Summary:
- Fix Python 3.13 SyntaxWarning (“invalid escape sequence \s”) in franken.py
- Use a raw string for the JavaScript regex to keep the same behavior without warnings
- Verified fix with: python3.13 -W error::SyntaxWarning -c "import monsterui.franken"

## Original error message:
const slug = (s) => s.toLowerCase().trim().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-');
/app/.venv/lib/python3.13/site-packages/monsterui/franken.py:1634: SyntaxWarning: invalid escape sequence '\s'

