### PR TITLE
Fix SyntaxWarning: use raw string for spy_js regex

### DIFF
--- a/monsterui/franken.py
+++ b/monsterui/franken.py
@@ -1630,7 +1630,7 @@ def ApexChart(*,
     return Div(Uk_chart(js), cls=stringify(cls), **kws)
 
 # %% ../nbs/02_franken.ipynb
-spy_js = '''
+spy_js = r'''
 const slug = (s) => s.toLowerCase().trim().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-');
 const frag = document.createDocumentFragment();
 

--- a/nbs/02_franken.ipynb
+++ b/nbs/02_franken.ipynb
@@ -3488,7 +3488,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "spy_js = '''\n",
+    "spy_js = r'''\n",
     "const slug = (s) => s.toLowerCase().trim().replace(/[^a-z0-9\\s-]/g, '').replace(/\\s+/g, '-').replace(/-+/g, '-');\n",
     "const frag = document.createDocumentFragment();\n",
     "\n",


### PR DESCRIPTION
Python 3.12 raises a `SyntaxWarning` for invalid escape sequences like `\s` in regular strings.

This PR changes `spy_js = '''` to `spy_js = r'''` (raw string literal) to fix the warning.

Fixes #145