### PR TITLE
Use style over class for dynamic padding

### DIFF
--- a/monsterui/franken.py
+++ b/monsterui/franken.py
@@ -1643,8 +1643,9 @@ document.querySelector('%s').querySelectorAll('%s').forEach((h,i) => {
   const id = slug(text)+'_'+i; h.id = id;
   const li = document.createElement('li'), a = document.createElement('a');
   const l = parseInt(h.tagName[1]) || 6;
-  li.className = `[&.uk-active]:bg-[hsl(var(--primary)/0.4)] uk-rounded pl-[${(l - 1) * 0.75}rem] text-sm`;
+  li.className = `[&.uk-active]:bg-[hsl(var(--primary)/0.4)] rounded-sm text-sm`;
   a.href = '#'+id; a.textContent = text;
+  li.style.paddingLeft = `${(l - 1) * 0.75}rem`;
   a.className = '!line-clamp-1';
   li.append(a); frag.append(li);
 });

--- a/nbs/01_core.ipynb
+++ b/nbs/01_core.ipynb
@@ -552,7 +552,13 @@
    "source": []
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/nbs/02_franken.ipynb
+++ b/nbs/02_franken.ipynb
@@ -4238,8 +4238,9 @@
     "  const id = slug(text)+'_'+i; h.id = id;\n",
     "  const li = document.createElement('li'), a = document.createElement('a');\n",
     "  const l = parseInt(h.tagName[1]) || 6;\n",
-    "  li.className = `[&.uk-active]:bg-[hsl(var(--primary)/0.4)] uk-rounded pl-[${(l - 1) * 0.75}rem] text-sm`;\n",
+    "  li.className = `[&.uk-active]:bg-[hsl(var(--primary)/0.4)] rounded-sm text-sm`;\n",
     "  a.href = '#'+id; a.textContent = text;\n",
+    "  li.style.paddingLeft = `${(l - 1) * 0.75}rem`;\n",
     "  a.className = '!line-clamp-1';\n",
     "  li.append(a); frag.append(li);\n",
     "});\n",
@@ -4373,7 +4374,13 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
This PR changes the dynamic tailwind class assignment in the scrollspy component to use standard styling. This is to support tailwind build processes, which cannot detect and build dynamic classes.